### PR TITLE
Add TypeScript interfaces for interview data models

### DIFF
--- a/interview-app/src/types.ts
+++ b/interview-app/src/types.ts
@@ -1,0 +1,37 @@
+export interface Interview {
+  id: number;
+  title: string;
+  job_role: string;
+  description?: string;
+  status: string;
+  username: string;
+}
+
+export interface Question {
+  id: number;
+  interview_id: number;
+  question: string;
+  difficulty: string;
+  username: string;
+}
+
+export interface Applicant {
+  id: number;
+  interview_id: number;
+  title: string;
+  firstname: string;
+  surname: string;
+  phone_number?: string;
+  email_address: string;
+  interview_status: string;
+  username: string;
+}
+
+export interface ApplicantAnswer {
+  id: number;
+  interview_id: number;
+  question_id: number;
+  applicant_id: number;
+  answer?: string;
+  username: string;
+}


### PR DESCRIPTION
## Summary
- add a shared `types.ts` file defining the Interview, Question, Applicant, and ApplicantAnswer interfaces for the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d10c727ce4832aba5a22d09b52239c