### PR TITLE
Refine interview types

### DIFF
--- a/interview-app/src/types.ts
+++ b/interview-app/src/types.ts
@@ -5,14 +5,16 @@ export interface Interview {
   description?: string;
   status: string;
   username: string;
+  created_at?: string;
 }
 
 export interface Question {
   id: number;
   interview_id: number;
   question: string;
-  difficulty: string;
+  difficulty: 'Easy' | 'Intermediate' | 'Advanced';
   username: string;
+  created_at?: string;
 }
 
 export interface Applicant {
@@ -23,8 +25,9 @@ export interface Applicant {
   surname: string;
   phone_number?: string;
   email_address: string;
-  interview_status: string;
+  interview_status: 'Not Started' | 'Completed';
   username: string;
+  created_at?: string;
 }
 
 export interface ApplicantAnswer {
@@ -34,4 +37,5 @@ export interface ApplicantAnswer {
   applicant_id: number;
   answer?: string;
   username: string;
+  created_at?: string;
 }


### PR DESCRIPTION
## Summary
- restrict question difficulty to defined levels and applicant interview status to key stages
- add optional created_at timestamp to core interview-related interfaces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d118bf9880832aab26689553a0bcdb