### PR TITLE
Add configuration safety tasks to checklist

### DIFF
--- a/docs/TaskList.md
+++ b/docs/TaskList.md
@@ -17,3 +17,5 @@
 - [ ] Audit and satisfy accessibility requirements.
 - [ ] Add the required disclosure to the README.
 - [ ] Write and maintain the necessary automated tests.
+- [ ] Ensure the LLM key persists solely in `llm-service/config.local.json`, with the repository shipping only `config.sample.json`.
+- [ ] Confirm `.gitignore` excludes `config.local.json` and the README clearly instructs contributors not to expose keys.


### PR DESCRIPTION
## Summary
- add checklist item ensuring the LLM key only lives in config.local.json and repo ships a sample
- document checklist item covering .gitignore of config.local.json and README key handling guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1201ee910832ab91a91d9b5611730